### PR TITLE
Restore stats rendering

### DIFF
--- a/index.html
+++ b/index.html
@@ -103,7 +103,7 @@
 
             <div class="section">
                 <div class="section-title">선수별 통계</div>
-                <div class="filter-controls">
+                <div class="filter-controls player-filter-controls">
                     <button class="filter-btn active" data-filter="all" onclick="filterPlayers('all')">전체</button>
                     <button class="filter-btn" data-filter="goals" onclick="filterPlayers('goals')">골 순</button>
                     <button class="filter-btn" data-filter="attendance" onclick="filterPlayers('attendance')">참석 순</button>
@@ -131,12 +131,13 @@
         <div id="allTimeContent" class="all-time-content" style="display: none;">
             <div class="section">
                 <div class="section-title">역대 선수 기록</div>
-                <div class="filter-controls">
+                <div class="filter-controls player-filter-controls">
                     <button class="filter-btn active" data-filter="all" onclick="filterPlayers('all')">전체</button>
                     <button class="filter-btn" data-filter="goals" onclick="filterPlayers('goals')">골 순</button>
                     <button class="filter-btn" data-filter="attendance" onclick="filterPlayers('attendance')">참석 순</button>
                     <button class="filter-btn" data-filter="mvp" onclick="filterPlayers('mvp')">MVP 횟수</button>
                 </div>
+                <div id="allTimeHighlights" class="all-time-highlights"></div>
                 <div class="table-container">
                     <table class="players-table">
                         <thead>
@@ -161,7 +162,7 @@
 
             <div class="regional-records-section">
                 <div class="section-title">🗺️ 지역별 경기 기록</div>
-                <div class="filter-controls">
+                <div class="filter-controls regional-filter-controls">
                     <button class="filter-btn" data-filter="matches" onclick="filterRegional('matches')">경기수 순</button>
                     <button class="filter-btn active" data-filter="winrate" onclick="filterRegional('winrate')">승률 순</button>
                     <button class="filter-btn" data-filter="wins" onclick="filterRegional('wins')">승수 순</button>

--- a/styles.css
+++ b/styles.css
@@ -548,6 +548,80 @@ body {
     flex-wrap: wrap;
 }
 
+.all-time-highlights {
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(180px, 1fr));
+    gap: 12px;
+    margin-bottom: 15px;
+}
+
+.all-time-highlights .highlight-card {
+    background: white;
+    border: 1px solid #e2e8f0;
+    border-radius: 12px;
+    padding: 12px 15px;
+    box-shadow: 0 4px 12px rgba(0, 0, 0, 0.05);
+}
+
+.all-time-highlights .highlight-title {
+    font-size: 0.85em;
+    color: #64748b;
+    margin-bottom: 6px;
+}
+
+.all-time-highlights .highlight-value {
+    font-size: 1.2em;
+    font-weight: bold;
+    color: #1e40af;
+}
+
+.team-overview,
+.team-highlights {
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(160px, 1fr));
+    gap: 12px;
+    margin-bottom: 15px;
+}
+
+.team-overview div,
+.team-highlights div {
+    background: white;
+    border: 1px solid #e2e8f0;
+    border-radius: 12px;
+    padding: 10px 12px;
+    box-shadow: 0 2px 6px rgba(0, 0, 0, 0.05);
+}
+
+.team-overview span,
+.team-highlights span {
+    display: block;
+    font-size: 0.8em;
+    color: #64748b;
+    margin-bottom: 4px;
+}
+
+.team-overview strong,
+.team-highlights strong {
+    font-size: 1.1em;
+    color: #1e3a8a;
+}
+
+.schedule-list {
+    list-style: none;
+    padding-left: 0;
+    display: flex;
+    flex-direction: column;
+    gap: 10px;
+}
+
+.schedule-list li {
+    background: white;
+    border-radius: 10px;
+    padding: 10px 12px;
+    border: 1px solid #e2e8f0;
+    box-shadow: 0 1px 4px rgba(0, 0, 0, 0.05);
+}
+
 .filter-btn {
     padding: 8px 15px;
     border: 2px solid #1e40af;


### PR DESCRIPTION
## Summary
- wire up the player and regional filter controls and add an all-time highlight container so the UI can surface the new stats
- style the new highlight cards, team overview widgets, and next-match schedule list so they blend into the dashboard
- rebuild the front-end logic: validate/sanitize JSON, implement the missing filters/toggles/summaries, refresh the schedule+map placeholders, and load all-time data without runtime errors

## Testing
- Not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691c186fb1b8832981af499f0ba0ef4d)