### PR TITLE
Improve all-time view and Kakao map integration

### DIFF
--- a/index.html
+++ b/index.html
@@ -213,7 +213,7 @@
             </div>
         </div>
 
-        <div class="schedule-venue-section next-matches-section">
+        <div id="scheduleSection" class="schedule-venue-section next-matches-section">
             <div class="section-title">다음 경기 일정 및 구장 위치</div>
             <div class="schedule-and-map">
                 <div class="schedule-container">


### PR DESCRIPTION
## Summary
- hide the schedule/venue section whenever the all-time tab is active
- upgrade the Kakao map integration so the widget renders with real geocoding data from the configured venue and only loads the SDK once
- ensure venue/schedule updates sanitize data, preserve fallbacks, and keep the view state consistent across season/all-time toggles

## Testing
- python -m http.server 8000 (manual)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691c1e0bb8d483298ccf5fd0760c1f4a)