### PR TITLE
Improve all-time stats cards and regional heatmap

### DIFF
--- a/index.html
+++ b/index.html
@@ -59,17 +59,17 @@
 
         <div class="stats-overview">
             <div class="stat-card">
-                <div class="stat-title">경기 수</div>
+                <div class="stat-title" id="matchesCardTitle">경기 수</div>
                 <div class="stat-value" id="totalMatches">0</div>
                 <div class="stat-subtitle">총 경기</div>
             </div>
             <div class="stat-card">
-                <div class="stat-title">승률</div>
+                <div class="stat-title" id="winRateCardTitle">승률</div>
                 <div class="stat-value" id="winRate">0%</div>
                 <div class="stat-subtitle" id="winRateSubtitle">0승 0무 0패</div>
             </div>
             <div class="stat-card">
-                <div class="stat-title">득점</div>
+                <div class="stat-title" id="goalsCardTitle">득점</div>
                 <div class="stat-value" id="totalGoals">0</div>
                 <div class="stat-subtitle" id="goalsPerMatch">경기당 0골</div>
             </div>


### PR DESCRIPTION
## Summary
- update the overview stat cards to switch labels and values when viewing all-time records
- aggregate team and regional all-time data across every season to keep win/draw/loss and MVP counts accurate
- rebuild the regional heatmap as a colored grid so all-time regional results are visualized again

## Testing
- Not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691e4fb876908329b449ba8a96e83edd)