### PR TITLE
Adjust all-time layouts and regional view

### DIFF
--- a/styles.css
+++ b/styles.css
@@ -403,14 +403,18 @@ body {
     border-radius: 15px;
     margin-top: 30px;
     grid-column: 1 / -1;
-    height: 450px;
+    height: 620px;
     display: flex;
     flex-direction: column;
     gap: 14px;
 }
 
+.regional-records-section .table-container {
+    max-height: 380px;
+}
+
 .all-time-view .regional-records-section {
-    height: 550px;
+    height: 620px;
 }
 
 .winrate-cell {
@@ -619,11 +623,11 @@ body {
 }
 
 .heatmap-card {
-    background: #fff;
+    background: #f8f9fa;
     border: 1px solid #e5e7eb;
     border-radius: 14px;
     padding: 16px;
-    box-shadow: 0 4px 10px rgba(0,0,0,0.05);
+    box-shadow: none;
     width: 100%;
 }
 
@@ -631,6 +635,7 @@ body {
 .all-time-content .team-records-section,
 .all-time-content .regional-records-section {
     height: 520px;
+    overflow-y: auto;
 }
 
 .all-time-content .table-container {
@@ -791,12 +796,17 @@ body {
     }
 
 
-    .players-table th, .players-table td, 
+    .players-table th, .players-table td,
     .matches-table th, .matches-table td,
     .regional-table th, .regional-table td {
         padding: 3px 5px !important;
         font-size: 0.8em !important;
         line-height: 1.3 !important;
+    }
+
+    .table-container {
+        max-height: 340px;
+        overflow-y: auto;
     }
 
     .mvp-badge {


### PR DESCRIPTION
## Summary
- restore mobile table scroll areas to show around seven rows
- align all-time player and team record card sizing while scrolling as a single unit
- expand regional records view to show more rows and unify heatmap background styling

## Testing
- Not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691e5de9399883299afd75d44a0e04d8)