### PR TITLE
Restore mobile scroll on all-time tables

### DIFF
--- a/styles.css
+++ b/styles.css
@@ -809,6 +809,12 @@ body {
         overflow-y: auto;
     }
 
+    .all-time-content .table-container {
+        max-height: 280px;
+        min-height: 0;
+        overflow-y: auto;
+    }
+
     .mvp-badge {
         font-size: 0.65em;
         padding: 1px 4px;


### PR DESCRIPTION
## Summary
- restore vertical scrolling for all-time record tables on mobile by capping their height
- keep table containers compact while maintaining overflow behavior

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691e6e38bce88329835008d6b5cb364e)