### PR TITLE
Use robust score parsing when calculating goals

### DIFF
--- a/script.js
+++ b/script.js
@@ -487,10 +487,8 @@ function updateStats() {
 
     let totalGoalsFor = 0;
     AppState.data.matches.forEach(match => {
-        const [goalsFor] = match.score.split(':').map(Number);
-        if (!isNaN(goalsFor)) {
-            totalGoalsFor += goalsFor;
-        }
+        const { goalsFor } = parseScore(match.score);
+        totalGoalsFor += goalsFor;
     });
 
     const winRate = totalMatches > 0 ? (wins / totalMatches * 100).toFixed(1) : 0;


### PR DESCRIPTION
## Summary
- use the existing parseScore helper when summing goals to handle malformed scores

## Testing
- not run (not available)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6940dce448548329ab8673538e6802ee)