### PR TITLE
Add festive year-end awards section

### DIFF
--- a/index.html
+++ b/index.html
@@ -219,6 +219,28 @@
                 </div>
             </div>
         </div>
+
+        <div id="yearEndSection" class="year-end-section">
+            <div class="section-title">2025 연말 시상식</div>
+            <div class="year-end-description">이번 주 토요일 송년회 하이라이트! 한 해를 빛낸 스타들을 만나보세요.</div>
+            <div id="yearEndAwards" class="year-end-awards">
+                <div class="award-card award-mvp">
+                    <div class="award-ribbon">시즌 MVP</div>
+                    <div class="award-winner" id="awardMvp">-</div>
+                    <div class="award-detail" id="awardMvpDetail">올해의 주인공</div>
+                </div>
+                <div class="award-card award-attendance">
+                    <div class="award-ribbon">최다 참석</div>
+                    <div class="award-winner" id="awardAttendance">-</div>
+                    <div class="award-detail" id="awardAttendanceDetail">꾸준함의 표본</div>
+                </div>
+                <div class="award-card award-scorer">
+                    <div class="award-ribbon">최다 득점</div>
+                    <div class="award-winner" id="awardScorer">-</div>
+                    <div class="award-detail" id="awardScorerDetail">올해의 파이어포워드</div>
+                </div>
+            </div>
+        </div>
     </div>
     
     <script src="./script.js" defer></script>

--- a/script.js
+++ b/script.js
@@ -511,6 +511,53 @@ function updateStats() {
     document.getElementById('mvpStats').textContent = mvpCount > 0 ? `MVP ${mvpCount}회 (출전 ${mvpAppearances}회)` : 'MVP 0회';
 }
 
+function getAwardLeader(players, key) {
+    return Object.entries(players || {}).reduce((best, [name, stats]) => {
+        const value = Number(stats?.[key]) || 0;
+        if (!best || value > best.value) {
+            return { name, value };
+        }
+        return best;
+    }, null);
+}
+
+function updateYearEndAwards() {
+    const section = document.getElementById('yearEndSection');
+    const awardsContainer = document.getElementById('yearEndAwards');
+    if (!section || !awardsContainer) return;
+
+    const seasonKey = '2025';
+    const seasonData = AppState.data.currentSeason === seasonKey
+        ? { players: AppState.data.playerStats }
+        : seasonDataCache.get(seasonKey);
+
+    if (!seasonData || !seasonData.players || Object.keys(seasonData.players).length === 0) {
+        section.style.display = 'none';
+        return;
+    }
+
+    section.style.display = 'block';
+
+    const mvp = getAwardLeader(seasonData.players, 'mvp');
+    const attendance = getAwardLeader(seasonData.players, 'appearances');
+    const scorer = getAwardLeader(seasonData.players, 'goals');
+
+    const mvpName = mvp ? mvp.name : '-';
+    const attendanceName = attendance ? attendance.name : '-';
+    const scorerName = scorer ? scorer.name : '-';
+
+    const mvpDetail = mvp ? `MVP ${mvp.value}회` : '데이터 없음';
+    const attendanceDetail = attendance ? `${attendance.value}경기 출전` : '데이터 없음';
+    const scorerDetail = scorer ? `${scorer.value}골 기록` : '데이터 없음';
+
+    document.getElementById('awardMvp').textContent = mvpName;
+    document.getElementById('awardMvpDetail').textContent = mvpDetail;
+    document.getElementById('awardAttendance').textContent = attendanceName;
+    document.getElementById('awardAttendanceDetail').textContent = attendanceDetail;
+    document.getElementById('awardScorer').textContent = scorerName;
+    document.getElementById('awardScorerDetail').textContent = scorerDetail;
+}
+
 // 테이블 업데이트 (부분 생략)
 function updateMatchesTable(matches = AppState.data.matches) {
     const tbody = document.getElementById('matchesTableBody');
@@ -854,6 +901,7 @@ async function loadData() {
         updateSchedule(data.schedules || []);
         updateRegionalTable(AppState.data.regionalStats, AppState.ui.currentRegionalFilter);
         createRegionalHeatmap(AppState.data.regionalStats);
+        updateYearEndAwards();
 
         if (data.schedules && data.schedules.length > 0) {
              loadKakaoMap();

--- a/styles.css
+++ b/styles.css
@@ -6,9 +6,31 @@
 
 body {
     font-family: 'Arial', sans-serif;
-    background: linear-gradient(90deg, #1e3a8a, #3b82f6, #60a5fa, #fbbf24, #f59e0b);
+    background: radial-gradient(circle at 20% 20%, rgba(255, 233, 180, 0.12), transparent 35%),
+                radial-gradient(circle at 80% 10%, rgba(255, 204, 229, 0.18), transparent 32%),
+                linear-gradient(135deg, #0b1224, #0f172a 40%, #1f2937 70%, #0f172a);
     min-height: 100vh;
     padding: 20px;
+    color: #e5e7eb;
+    position: relative;
+    overflow-x: hidden;
+}
+
+body::before {
+    content: '';
+    position: fixed;
+    inset: 0;
+    background-image: radial-gradient(2px 2px at 20% 30%, rgba(255, 255, 255, 0.9), transparent),
+                      radial-gradient(1.5px 1.5px at 80% 40%, rgba(255, 255, 255, 0.8), transparent),
+                      radial-gradient(1px 1px at 50% 70%, rgba(255, 255, 255, 0.75), transparent);
+    opacity: 0.5;
+    pointer-events: none;
+    animation: snowfall 18s linear infinite;
+}
+
+@keyframes snowfall {
+    from { transform: translateY(-10px); }
+    to { transform: translateY(20px); }
 }
 
 .container {
@@ -18,6 +40,7 @@ body {
     border-radius: 20px;
     padding: 30px;
     box-shadow: 0 15px 35px rgba(0, 0, 0, 0.1);
+    color: #0f172a;
 }
 
 .header {
@@ -546,6 +569,111 @@ body {
 .venue-phone {
     color: #666;
     font-size: 0.9em;
+}
+
+.year-end-section {
+    margin-top: 50px;
+    padding: 35px;
+    border-radius: 18px;
+    background: linear-gradient(135deg, rgba(255, 255, 255, 0.1), rgba(255, 236, 194, 0.2));
+    border: 1px solid rgba(255, 255, 255, 0.08);
+    box-shadow: 0 20px 40px rgba(15, 23, 42, 0.35);
+    position: relative;
+    overflow: hidden;
+}
+
+.year-end-section::after {
+    content: '';
+    position: absolute;
+    inset: -60px auto auto -60px;
+    width: 180px;
+    height: 180px;
+    background: radial-gradient(circle, rgba(248, 180, 0, 0.2), transparent 60%);
+    filter: blur(10px);
+    pointer-events: none;
+}
+
+.year-end-section::before {
+    content: '';
+    position: absolute;
+    inset: auto -50px -50px auto;
+    width: 200px;
+    height: 200px;
+    background: radial-gradient(circle, rgba(59, 130, 246, 0.2), transparent 60%);
+    filter: blur(12px);
+    pointer-events: none;
+}
+
+.year-end-description {
+    text-align: center;
+    color: #f3f4f6;
+    margin-top: -6px;
+    margin-bottom: 18px;
+    font-weight: 500;
+    letter-spacing: 0.02em;
+}
+
+.year-end-awards {
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(240px, 1fr));
+    gap: 18px;
+    position: relative;
+    z-index: 1;
+}
+
+.award-card {
+    position: relative;
+    padding: 24px 20px;
+    border-radius: 16px;
+    color: #0f172a;
+    background: linear-gradient(145deg, #fffef8, #f2f6ff);
+    box-shadow: 0 12px 30px rgba(0, 0, 0, 0.15);
+    overflow: hidden;
+    border: 1px solid rgba(255, 255, 255, 0.4);
+}
+
+.award-card::after {
+    content: '';
+    position: absolute;
+    inset: 0;
+    background: radial-gradient(circle at 20% 20%, rgba(255, 255, 255, 0.55), transparent 40%);
+    pointer-events: none;
+}
+
+.award-ribbon {
+    display: inline-block;
+    padding: 8px 14px;
+    border-radius: 999px;
+    font-weight: 800;
+    letter-spacing: 0.02em;
+    color: #0f172a;
+    background: linear-gradient(135deg, #fde68a, #fca5a5);
+    box-shadow: 0 6px 18px rgba(252, 165, 165, 0.5);
+}
+
+.award-winner {
+    margin-top: 16px;
+    font-size: 1.6em;
+    font-weight: 800;
+    color: #0f172a;
+}
+
+.award-detail {
+    margin-top: 8px;
+    color: #475569;
+    font-weight: 600;
+}
+
+.award-mvp {
+    background: linear-gradient(140deg, #fff6e3, #ffe4e6);
+}
+
+.award-attendance {
+    background: linear-gradient(140deg, #e0f2fe, #e0f7f3);
+}
+
+.award-scorer {
+    background: linear-gradient(140deg, #fef3c7, #fdf2f8);
 }
 
 .filter-controls {


### PR DESCRIPTION
## Summary
- refresh the layout with a winter holiday-inspired background and updated container styling
- add a 2025 연말 시상식 section showcasing MVP, attendance leader, and top scorer cards near the bottom of the page
- populate the new award cards from season data when the 2025 season is loaded or cached

## Testing
- Not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694b3d6210a08329b24de10e1c9d823a)