### PR TITLE
Increase blur for season MVP card

### DIFF
--- a/styles.css
+++ b/styles.css
@@ -184,9 +184,10 @@ body::before {
 }
 
 .season-mvp-faded {
-    opacity: 0.6;
-    filter: blur(1px);
+    opacity: 0.35;
+    filter: blur(2.5px);
     transition: opacity 0.35s ease, filter 0.35s ease;
+    pointer-events: none;
 }
 
 .stat-title {


### PR DESCRIPTION
## Summary
- strengthen the fade effect on the season MVP stat card
- reduce opacity, increase blur, and disable pointer interactions to keep the card discreet

## Testing
- no automated tests were run (UI change only)
- captured a screenshot of the updated card


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694b46a2f8e88329a47e751803683d5d)