### PR TITLE
Add 2025 season stat overrides and MVP reveal hint

### DIFF
--- a/index.html
+++ b/index.html
@@ -80,6 +80,10 @@
             </div>
         </div>
 
+        <div id="mvpRevealHint" class="mvp-hint" style="display: none;">
+            시즌 MVP는 아래 <strong>2025 연말 시상식</strong> 카드에서 확인해 주세요.
+        </div>
+
         <div id="mainContent" class="main-content">
             <div class="section" id="matchesSection">
                 <div class="section-title">최근 경기 결과</div>

--- a/styles.css
+++ b/styles.css
@@ -184,10 +184,21 @@ body::before {
 }
 
 .season-mvp-faded {
-    opacity: 0.15;
-    filter: blur(6px);
+    opacity: 0.08;
+    filter: blur(10px);
     transition: opacity 0.35s ease, filter 0.35s ease;
     pointer-events: none;
+}
+
+.mvp-hint {
+    margin: -6px 0 26px;
+    color: #b91c1c;
+    font-weight: 700;
+    text-align: center;
+    background: rgba(255, 228, 230, 0.6);
+    border: 1px dashed #fca5a5;
+    padding: 10px 14px;
+    border-radius: 12px;
 }
 
 .stat-title {


### PR DESCRIPTION
## Summary
- add explicit 2025 season overrides for win/loss, goals, and MVP counts
- intensify the blur on the season MVP card and show a hint that directs users to the 2025 year-end awards card
- allow the year-end awards block to display overridden MVP details even when player rows are missing

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694b49aba5908329b0eefff8ebf1e609)