### PR TITLE
Use season data for stats and mosaic MVP card

### DIFF
--- a/script.js
+++ b/script.js
@@ -504,28 +504,40 @@ function updateStats() {
     }
 
     const override = SEASON_DISPLAY_OVERRIDES[AppState.data.currentSeason];
+    const hasMatchData = AppState.data.matches.length > 0;
+    const hasPlayerData = Object.keys(AppState.data.playerStats || {}).length > 0;
 
-    const totalMatches = override?.summary?.matches ?? AppState.data.matches.length;
-    const wins = override?.summary?.wins ?? AppState.data.matches.filter(match => match.result === 'win').length;
-    const draws = override?.summary?.draws ?? AppState.data.matches.filter(match => match.result === 'draw').length;
-    const losses = override?.summary?.losses ?? AppState.data.matches.filter(match => match.result === 'loss').length;
+    const totalMatches = hasMatchData
+        ? AppState.data.matches.length
+        : override?.summary?.matches ?? 0;
+    const wins = hasMatchData
+        ? AppState.data.matches.filter(match => match.result === 'win').length
+        : override?.summary?.wins ?? 0;
+    const draws = hasMatchData
+        ? AppState.data.matches.filter(match => match.result === 'draw').length
+        : override?.summary?.draws ?? 0;
+    const losses = hasMatchData
+        ? AppState.data.matches.filter(match => match.result === 'loss').length
+        : override?.summary?.losses ?? 0;
 
     let totalGoalsFor = 0;
-    if (override?.summary?.goalsFor !== undefined) {
-        totalGoalsFor = override.summary.goalsFor;
-    } else {
+    if (hasMatchData) {
         AppState.data.matches.forEach(match => {
             const [goalsFor] = match.score.split(':').map(Number);
             if (!isNaN(goalsFor)) {
                 totalGoalsFor += goalsFor;
             }
         });
+    } else if (override?.summary?.goalsFor !== undefined) {
+        totalGoalsFor = override.summary.goalsFor;
     }
 
     const winRate = totalMatches > 0 ? (wins / totalMatches * 100).toFixed(1) : 0;
     const goalsPerMatch = totalMatches > 0 ? (totalGoalsFor / totalMatches).toFixed(1) : 0;
 
-    const seasonMvpPlayer = override?.mvp ?? calculateSeasonMvp(AppState.data.playerStats);
+    const seasonMvpPlayer = hasPlayerData
+        ? calculateSeasonMvp(AppState.data.playerStats)
+        : override?.mvp;
     const mvpName = seasonMvpPlayer ? seasonMvpPlayer.name : '-';
     const mvpCount = seasonMvpPlayer ? seasonMvpPlayer.count ?? seasonMvpPlayer.mvp : 0;
     const mvpAppearances = seasonMvpPlayer ? seasonMvpPlayer.appearances : 0;

--- a/styles.css
+++ b/styles.css
@@ -184,10 +184,25 @@ body::before {
 }
 
 .season-mvp-faded {
-    opacity: 0.4;
-    filter: blur(6px);
+    position: relative;
+    overflow: hidden;
     transition: opacity 0.35s ease, filter 0.35s ease;
     pointer-events: none;
+}
+
+.season-mvp-faded * {
+    filter: blur(14px);
+}
+
+.season-mvp-faded::after {
+    content: "";
+    position: absolute;
+    inset: 0;
+    background-image:
+        linear-gradient(45deg, rgba(255, 255, 255, 0.2) 25%, transparent 25%, transparent 50%, rgba(255, 255, 255, 0.2) 50%, rgba(255, 255, 255, 0.2) 75%, transparent 75%, transparent),
+        linear-gradient(-45deg, rgba(255, 255, 255, 0.2) 25%, transparent 25%, transparent 50%, rgba(255, 255, 255, 0.2) 50%, rgba(255, 255, 255, 0.2) 75%, transparent 75%, transparent);
+    background-size: 16px 16px;
+    opacity: 0.9;
 }
 
 .mvp-hint {


### PR DESCRIPTION
## Summary
- derive the overview stat cards from loaded season data instead of hardcoded overrides
- apply a mosaic-style blur to the season MVP card when it should be hidden

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694b9462cbd88329b3720405de87faaa)