### PR TITLE
Improve data loading and UI reliability

### DIFF
--- a/index.html
+++ b/index.html
@@ -46,7 +46,12 @@
                     <option value="2001">2001 시즌</option>
                     <option value="2000">2000 시즌</option>
                 </select>
-                <button id="allTimeButton" class="all-time-button" onclick="toggleAllTimeView()">
+                <button 
+                    id="allTimeButton" 
+                    class="all-time-button" 
+                    onclick="toggleAllTimeView()"
+                    aria-label="역대 기록 보기/숨기기"
+                    aria-pressed="false">
                     📊 역대 기록
                 </button>
             </div>

--- a/styles.css
+++ b/styles.css
@@ -4,6 +4,13 @@
     box-sizing: border-box;
 }
 
+:root {
+    --mobile-padding: 15px;
+    --mobile-font-size: 1em;
+    --mobile-button-padding: 10px 15px;
+    --mobile-table-font-size: 0.8em;
+}
+
 body {
     font-family: 'Arial', sans-serif;
     background: radial-gradient(circle at 18% 22%, rgba(255, 233, 181, 0.35), transparent 36%),
@@ -928,7 +935,7 @@ body::before {
 
 @media (max-width: 768px) {
     .container {
-        padding: 15px;
+        padding: var(--mobile-padding);
     }
 
     .season-selector {
@@ -938,8 +945,8 @@ body::before {
 
     .season-selector select, .all-time-button {
         min-width: 140px;
-        font-size: 1em;
-        padding: 10px 15px;
+        font-size: var(--mobile-font-size);
+        padding: var(--mobile-button-padding);
     }
 
     .main-content, .all-time-content {
@@ -963,7 +970,7 @@ body::before {
     .matches-table th, .matches-table td,
     .regional-table th, .regional-table td {
         padding: 3px 5px !important;
-        font-size: 0.8em !important;
+        font-size: var(--mobile-table-font-size) !important;
         line-height: 1.3 !important;
     }
 


### PR DESCRIPTION
## Summary
- add configurable data path helper and reusable match statistic utilities
- optimize seasonal stat calculations and enhance accessibility for the all-time toggle
- prevent duplicate Kakao map script loads and introduce shared mobile styling variables

## Testing
- Not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694b9899cc608329a13b8bd1fcd5888d)