### PR TITLE
Revamp UI: dark theme, card-based matches/players lists, top tabs, sorting & view state

### DIFF
--- a/index.html
+++ b/index.html
@@ -56,6 +56,13 @@
                     📊 역대 기록
                 </button>
             </div>
+            <nav class="top-tabbar" aria-label="메인 탐색">
+                <button class="top-tab active" data-tab="home" onclick="switchMainTab('home')">Home</button>
+                <button class="top-tab" data-tab="seasons" onclick="switchMainTab('seasons')">Seasons</button>
+                <button class="top-tab" data-tab="matches" onclick="switchMainTab('matches')">Matches</button>
+                <button class="top-tab" data-tab="players" onclick="switchMainTab('players')">Players</button>
+                <button class="top-tab" data-tab="records" onclick="switchMainTab('records')">Records</button>
+            </nav>
             <div id="statusMessage" class="status-message"></div>
             <div id="loadingProgress" class="loading-progress">
                 <div id="loadingProgressBar" class="loading-progress-bar"></div>
@@ -63,7 +70,13 @@
             <div id="loadingStats" class="loading-stats"></div>
         </div>
 
-        <div class="stats-overview">
+        <div class="hero-panel">
+            <div class="hero-kicker">WHISTLE ARCHIVE</div>
+            <div class="hero-title">팀 중심 기록 대시보드</div>
+            <div class="hero-subtitle">시즌 · 경기 · 선수 · 역대 기록을 한눈에 확인하세요</div>
+        </div>
+
+        <div class="stats-overview" id="statsOverview">
             <div class="stat-card">
                 <div class="stat-title" id="matchesCardTitle">경기 수</div>
                 <div class="stat-value" id="totalMatches">0</div>
@@ -89,21 +102,12 @@
         <div id="mainContent" class="main-content">
             <div class="section" id="matchesSection">
                 <div class="section-title">최근 경기 결과</div>
-                <div class="table-container">
-                    <table class="matches-table">
-                        <thead>
-                            <tr>
-                                <th>날짜</th>
-                                <th>상대</th>
-                                <th>결과</th>
-                                <th>스코어</th>
-                                <th>MVP</th>
-                            </tr>
-                        </thead>
-                        <tbody id="matchesTableBody">
-                            <tr><td colspan="5" class="no-data">데이터를 불러오는 중...</td></tr>
-                        </tbody>
-                    </table>
+                <div class="filter-controls match-sort-controls">
+                    <button class="filter-btn active" data-match-sort="desc" onclick="setMatchSort('desc')">날짜 내림차순</button>
+                    <button class="filter-btn" data-match-sort="asc" onclick="setMatchSort('asc')">날짜 오름차순</button>
+                </div>
+                <div class="match-archive-list" id="matchesList">
+                    <div class="no-data">데이터를 불러오는 중...</div>
                 </div>
             </div>
 
@@ -115,21 +119,8 @@
                     <button class="filter-btn" data-filter="attendance" onclick="filterPlayers('attendance')">참석 순</button>
                     <button class="filter-btn" data-filter="mvp" onclick="filterPlayers('mvp')">MVP 횟수</button>
                 </div>
-                <div class="table-container">
-                    <table class="players-table">
-                        <thead>
-                            <tr id="playersTableHeader">
-                                <th>이름</th>
-                                <th>출전</th>
-                                <th>참석률</th>
-                                <th>골</th>
-                                <th>MVP</th>
-                            </tr>
-                        </thead>
-                        <tbody id="playersTableBody">
-                            <tr><td colspan="5" class="no-data">데이터를 불러오는 중...</td></tr>
-                        </tbody>
-                    </table>
+                <div class="player-ranking-list" id="playersRankList">
+                    <div class="no-data">데이터를 불러오는 중...</div>
                 </div>
             </div>
         </div>

--- a/script.js
+++ b/script.js
@@ -12,7 +12,9 @@ const AppState = {
     ui: {
         currentFilter: 'all',
         currentRegionalFilter: 'winrate',
-        currentTeamSort: 'season'
+        currentTeamSort: 'season',
+        currentMainTab: 'home',
+        currentMatchSort: 'desc'
     },
     data: {
         currentSeason: '2026',
@@ -565,38 +567,89 @@ function updateStats() {
 
 // 테이블 업데이트 (부분 생략)
 function updateMatchesTable(matches = AppState.data.matches) {
-    const tbody = document.getElementById('matchesTableBody');
-    if (!tbody) return;
-    
-    tbody.innerHTML = '';
+    const matchList = document.getElementById('matchesList');
+    if (!matchList) return;
+
+    matchList.innerHTML = '';
 
     if (!matches || matches.length === 0) {
-        tbody.innerHTML = '<tr><td colspan="5" class="no-data">경기 데이터가 없습니다.</td></tr>';
+        matchList.innerHTML = '<div class="no-data">경기 데이터가 없습니다.</div>';
         return;
     }
 
-    matches.forEach(match => {
-        const row = tbody.insertRow();
-        row.innerHTML = `
-            <td>${match.date}</td>
-            <td><strong>${match.opponent}</strong></td>
-            <td><span class="result-badge result-${match.result}">
-                ${match.result === 'win' ? '승' : match.result === 'draw' ? '무' : '패'}
-            </span></td>
-            <td><strong>${match.score}</strong></td>
-            <td>${match.mvp ? `<span class="mvp-badge">${match.mvp}</span>` : '-'}</td>
+    const withMeta = matches.map((match, index) => ({
+        ...match,
+        originalIndex: index,
+        timestamp: new Date(match.date).getTime()
+    }));
+
+    const chronological = [...withMeta].sort((a, b) => {
+        const timeA = Number.isFinite(a.timestamp) ? a.timestamp : 0;
+        const timeB = Number.isFinite(b.timestamp) ? b.timestamp : 0;
+        return timeA - timeB || a.originalIndex - b.originalIndex;
+    });
+
+    const roundKeyMap = new Map();
+    chronological.forEach((match, index) => {
+        const key = `${match.date}|${match.opponent}|${match.score}|${match.mvp}|${match.originalIndex}`;
+        roundKeyMap.set(key, index + 1);
+    });
+
+    const isAsc = AppState.ui.currentMatchSort === 'asc';
+    const displayMatches = [...withMeta].sort((a, b) => {
+        const timeA = Number.isFinite(a.timestamp) ? a.timestamp : 0;
+        const timeB = Number.isFinite(b.timestamp) ? b.timestamp : 0;
+        return isAsc ? (timeA - timeB || a.originalIndex - b.originalIndex) : (timeB - timeA || b.originalIndex - a.originalIndex);
+    });
+
+    document.querySelectorAll('.match-sort-controls .filter-btn').forEach(button => {
+        button.classList.toggle('active', button.dataset.matchSort === AppState.ui.currentMatchSort);
+    });
+
+    displayMatches.forEach(match => {
+        const roundKey = `${match.date}|${match.opponent}|${match.score}|${match.mvp}|${match.originalIndex}`;
+        const round = roundKeyMap.get(roundKey) || 1;
+        const card = document.createElement('article');
+        card.className = 'match-archive-item';
+        card.innerHTML = `
+            <div class="match-archive-top">
+                <span class="match-date">${match.date}</span>
+                <span class="match-competition">WHISTLE LEAGUE</span>
+            </div>
+            <div class="match-archive-main match-archive-grid">
+                <div class="match-opponent-wrap match-zone-left">
+                    <div class="match-opponent">${match.opponent}</div>
+                    <div class="match-context">HOME · WHISTLE</div>
+                </div>
+                <div class="match-mid-meta match-zone-center">
+                    <div class="match-meta-line">${round}라운드</div>
+                    <div class="match-meta-line">시즌 ${AppState.data.currentSeason}</div>
+                    <div class="match-meta-line">아카이브 경기</div>
+                </div>
+                <div class="match-score-wrap match-zone-right">
+                    <div class="match-score">${match.score}</div>
+                    <span class="result-badge result-${match.result}">
+                        ${match.result === 'win' ? '승' : match.result === 'draw' ? '무' : '패'}
+                    </span>
+                </div>
+            </div>
+            <div class="match-archive-meta">
+                <span class="match-meta-chip">${round}번째 기록</span>
+                <span class="match-meta-chip">MVP ${match.mvp ? match.mvp : '-'}</span>
+            </div>
         `;
+        matchList.appendChild(card);
     });
 }
 
 function updatePlayersTable(playerStats = AppState.data.playerStats, sortBy = AppState.ui.currentFilter) {
-    const tbody = document.getElementById('playersTableBody');
-    if (!tbody) return;
+    const listContainer = document.getElementById('playersRankList');
+    if (!listContainer) return;
 
-    tbody.innerHTML = '';
+    listContainer.innerHTML = '';
 
     if (!playerStats || Object.keys(playerStats).length === 0) {
-        tbody.innerHTML = '<tr><td colspan="5" class="no-data">선수 데이터가 없습니다.</td></tr>';
+        listContainer.innerHTML = '<div class="no-data">선수 데이터가 없습니다.</div>';
         return;
     }
 
@@ -621,20 +674,39 @@ function updatePlayersTable(playerStats = AppState.data.playerStats, sortBy = Ap
     const totalMatches = AppState.data.matches.length;
 
     playersArray.forEach((player, index) => {
-        const row = tbody.insertRow();
         const attendanceRate = totalMatches > 0 ? Math.round((player.appearances / totalMatches) * 100) : 0;
-        
-        row.innerHTML = `
-            <td><strong>${player.name}</strong></td>
-            <td><strong>${player.appearances}</strong></td>
-            <td><span class="attendance-rate ${
+
+        const card = document.createElement('article');
+        card.className = 'player-rank-item';
+        card.innerHTML = `
+            <div class="player-rank-order">${index + 1}</div>
+            <div class="player-rank-main player-zone-left">
+                <div class="player-name">${player.name}</div>
+                <div class="player-support">
+                    <span class="player-chip">출전 ${player.appearances}</span>
+                    <span class="player-chip">골 ${player.goals}</span>
+                    <span class="player-chip">MVP ${player.mvp}회</span>
+                </div>
+            </div>
+            <div class="player-rank-meta player-zone-center">
+                <span class="player-chip">포지션 미등록</span>
+                <span class="player-chip">경기 ${AppState.data.matches.length || 0}</span>
+            </div>
+            <div class="player-rank-stats player-zone-right">
+                <span class="attendance-rate ${
                 attendanceRate >= 70 ? 'rate-high' :
                 attendanceRate >= 40 ? 'rate-medium' : 'rate-low'
-            }">${attendanceRate}%</span></td>
-            <td>${player.goals}</td>
-            <td>${player.mvp > 0 ? `<span class="mvp-badge">${player.mvp}회</span>` : '0'}</td>
+            }">참석률 ${attendanceRate}%</span>
+                <span class="mvp-badge">MVP ${player.mvp}회</span>
+            </div>
         `;
+        listContainer.appendChild(card);
     });
+}
+
+function setMatchSort(sortOrder) {
+    AppState.ui.currentMatchSort = sortOrder;
+    updateMatchesTable(AppState.data.matches);
 }
 
 function updateTable(data, matches, tableBodyId, type) {
@@ -926,8 +998,8 @@ async function loadData() {
         AppState.data.regionalStats = data.regional || [];
         updateStats(); // 이 함수가 위에 정의되어 있으므로 이제 안전함
 
-        updateTable(AppState.data.playerStats, AppState.data.matches, 'playersTableBody', 'players');
-        updateTable(AppState.data.matches, [], 'matchesTableBody', 'matches');
+        updateTable(AppState.data.playerStats, AppState.data.matches, 'playersRankList', 'players');
+        updateTable(AppState.data.matches, [], 'matchesList', 'matches');
         updateSchedule(data.schedules || []);
         updateRegionalTable(AppState.data.regionalStats, AppState.ui.currentRegionalFilter);
         createRegionalHeatmap(AppState.data.regionalStats);
@@ -953,14 +1025,14 @@ async function loadData() {
         
         // 기본값으로 UI 업데이트
         updateStats();
-        const playersTableBody = document.getElementById('playersTableBody');
-        const matchesTableBody = document.getElementById('matchesTableBody');
-        
-        if (playersTableBody) {
-            playersTableBody.innerHTML = '<tr><td colspan="5" class="no-data">데이터를 불러올 수 없습니다.</td></tr>';
+        const playersRankList = document.getElementById('playersRankList');
+        const matchesList = document.getElementById('matchesList');
+
+        if (playersRankList) {
+            playersRankList.innerHTML = '<div class="no-data">데이터를 불러올 수 없습니다.</div>';
         }
-        if (matchesTableBody) {
-            matchesTableBody.innerHTML = '<tr><td colspan="5" class="no-data">데이터를 불러올 수 없습니다.</td></tr>';
+        if (matchesList) {
+            matchesList.innerHTML = '<div class="no-data">데이터를 불러올 수 없습니다.</div>';
         }
     }
 }
@@ -1460,19 +1532,18 @@ function updateButtonStates() {
 }
 
 function updateViewVisibility() {
-    const mainContent = document.getElementById('mainContent');
-    const allTimeContent = document.getElementById('allTimeContent');
-    const scheduleSection = document.getElementById('scheduleSection');
+    document.body.classList.remove(
+        'page-mode-home',
+        'page-mode-seasons',
+        'page-mode-matches',
+        'page-mode-players',
+        'page-mode-records'
+    );
+    document.body.classList.add(`page-mode-${AppState.ui.currentMainTab}`);
 
-    if (AppState.data.isAllTimeView) {
-        if (mainContent) mainContent.style.display = 'none';
-        if (allTimeContent) allTimeContent.style.display = 'grid';
-        if (scheduleSection) scheduleSection.style.display = 'none';
-    } else {
-        if (mainContent) mainContent.style.display = 'grid';
-        if (allTimeContent) allTimeContent.style.display = 'none';
-        if (scheduleSection) scheduleSection.style.display = 'block';
-    }
+    document.querySelectorAll('.top-tab').forEach(button => {
+        button.classList.toggle('active', button.dataset.tab === AppState.ui.currentMainTab);
+    });
 }
 
 function onSeasonSelectClick() {
@@ -1544,9 +1615,26 @@ async function toggleAllTimeView() {
     filterRegional(AppState.ui.currentRegionalFilter);
 }
 
+async function switchMainTab(tab) {
+    AppState.ui.currentMainTab = tab;
+
+    if (tab === 'records') {
+        if (!AppState.data.isAllTimeView) {
+            await toggleAllTimeView();
+            return;
+        }
+    } else if (AppState.data.isAllTimeView) {
+        await toggleAllTimeView();
+        return;
+    }
+
+    updateViewVisibility();
+}
+
 // 초기화/진입점 함수
 function initializeApp() {
     AppState.data.currentSeason = CONFIG.DEFAULT_SEASON;
+    AppState.ui.currentMainTab = 'home';
     
     // 초기 로드 시 시즌 통계 카드 구조를 먼저 그림
     renderSeasonStatCards();
@@ -1571,3 +1659,5 @@ window.onSeasonSelectClick = onSeasonSelectClick;
 window.filterPlayers = filterPlayers;
 window.filterRegional = filterRegional;
 window.filterTeamRecords = filterTeamRecords;
+window.switchMainTab = switchMainTab;
+window.setMatchSort = setMatchSort;

--- a/styles.css
+++ b/styles.css
@@ -5,14 +5,13 @@
 }
 
 body {
-    font-family: 'Arial', sans-serif;
-    background: radial-gradient(circle at 18% 22%, rgba(255, 224, 138, 0.35), transparent 36%),
-                radial-gradient(circle at 82% 12%, rgba(255, 165, 165, 0.32), transparent 32%),
-                radial-gradient(circle at 40% 78%, rgba(255, 214, 102, 0.25), transparent 34%),
-                linear-gradient(135deg, #fef08a 0%, #f59e0b 40%, #ef4444 100%);
+    font-family: 'Inter', 'Pretendard', 'Noto Sans KR', sans-serif;
+    background: radial-gradient(circle at 12% 10%, rgba(37, 99, 235, 0.18), transparent 30%),
+                radial-gradient(circle at 86% 15%, rgba(56, 189, 248, 0.16), transparent 30%),
+                linear-gradient(160deg, #020617 0%, #0f172a 50%, #111827 100%);
     min-height: 100vh;
     padding: 20px;
-    color: #7f1d1d;
+    color: #e2e8f0;
     position: relative;
     overflow-x: hidden;
 }
@@ -25,9 +24,9 @@ body::before {
                       radial-gradient(1.5px 1.5px at 80% 40%, rgba(255, 255, 255, 0.85), transparent),
                       radial-gradient(1px 1px at 50% 70%, rgba(255, 248, 225, 0.8), transparent),
                       radial-gradient(90px 90px at 60% 15%, rgba(255, 247, 210, 0.2), transparent 45%);
-    opacity: 0.55;
+    opacity: 0.2;
     pointer-events: none;
-    animation: snowfall 18s linear infinite;
+    animation: snowfall 30s linear infinite;
 }
 
 @keyframes snowfall {
@@ -38,31 +37,60 @@ body::before {
 .container {
     max-width: 1400px;
     margin: 0 auto;
-    background: rgba(255, 255, 255, 0.95);
+    background: rgba(15, 23, 42, 0.8);
+    border: 1px solid rgba(148, 163, 184, 0.2);
     border-radius: 20px;
     padding: 30px;
-    box-shadow: 0 15px 35px rgba(239, 68, 68, 0.12), 0 20px 50px rgba(245, 158, 11, 0.12);
-    color: #0f172a;
+    box-shadow: 0 18px 40px rgba(2, 6, 23, 0.45);
+    color: #e2e8f0;
 }
 
 .header {
-    text-align: center;
-    margin-bottom: 40px;
-    padding-bottom: 20px;
-    border-bottom: 3px solid #b91c1c;
+    text-align: left;
+    margin-bottom: 26px;
+    padding-bottom: 16px;
+    border-bottom: 1px solid rgba(148, 163, 184, 0.25);
+}
+
+.hero-panel {
+    background: linear-gradient(160deg, rgba(30, 41, 59, 0.95), rgba(15, 23, 42, 0.95));
+    border: 1px solid rgba(59, 130, 246, 0.35);
+    border-radius: 18px;
+    padding: 22px;
+    margin-bottom: 20px;
+}
+
+.hero-kicker {
+    color: #93c5fd;
+    font-size: 0.75rem;
+    letter-spacing: 0.12em;
+    text-transform: uppercase;
+    margin-bottom: 6px;
+}
+
+.hero-title {
+    font-size: 1.5rem;
+    font-weight: 700;
+    color: #f8fafc;
+    margin-bottom: 6px;
+}
+
+.hero-subtitle {
+    color: #94a3b8;
+    font-size: 0.95rem;
 }
 
 .team-name {
-    font-size: 2.5em;
-    color: #b91c1c;
-    margin-bottom: 10px;
+    font-size: 2.1em;
+    color: #f8fafc;
+    margin-bottom: 12px;
     font-weight: bold;
 }
 
 .season-selector {
-    margin-bottom: 0;
+    margin-bottom: 12px;
     display: flex;
-    justify-content: center;
+    justify-content: flex-start;
     align-items: center;
     gap: 15px;
 }
@@ -137,6 +165,10 @@ body::before {
     background: linear-gradient(135deg, #d97706, #b45309);
 }
 
+.all-time-button {
+    display: none;
+}
+
 .status-message {
     margin: 15px 0;
     padding: 12px 20px;
@@ -176,7 +208,8 @@ body::before {
 }
 
 .stat-card {
-    background: linear-gradient(135deg, #facc15, #ea580c, #b91c1c);
+    background: linear-gradient(145deg, #1e293b, #0f172a);
+    border: 1px solid rgba(59, 130, 246, 0.3);
     padding: 25px;
     border-radius: 15px;
     color: white;
@@ -292,38 +325,200 @@ body::before {
 }
 
 .section {
-    background: #f8f9fa;
+    background: rgba(15, 23, 42, 0.72);
+    border: 1px solid rgba(148, 163, 184, 0.22);
     padding: 25px;
     border-radius: 15px;
-    height: 450px;
+    min-height: 450px;
     display: flex;
     flex-direction: column;
 }
 
 .all-time-view .section {
-    height: 550px;
+    min-height: 520px;
 }
 
 .team-records-section {
-    background: #f8f9fa;
+    background: rgba(15, 23, 42, 0.72);
+    border: 1px solid rgba(148, 163, 184, 0.22);
     padding: 25px;
     border-radius: 15px;
-    height: 450px;
+    min-height: 450px;
     display: flex;
     flex-direction: column;
     overflow-y: auto;
 }
 
 .all-time-view .team-records-section {
-    height: 550px;
+    min-height: 520px;
 }
 
 .section-title {
     font-size: 1.5em;
-    color: #0f766e;
+    color: #f8fafc;
     margin-bottom: 20px;
     font-weight: bold;
     text-align: center;
+}
+
+.match-archive-list,
+.player-ranking-list {
+    display: flex;
+    flex-direction: column;
+    gap: 12px;
+    overflow-y: auto;
+    padding-right: 4px;
+    min-height: 0;
+}
+
+.match-archive-item {
+    background: linear-gradient(145deg, rgba(15, 23, 42, 0.96), rgba(30, 41, 59, 0.9));
+    border: 1px solid rgba(59, 130, 246, 0.25);
+    border-radius: 14px;
+    padding: 14px;
+    display: flex;
+    flex-direction: column;
+    gap: 10px;
+    transition: transform 0.2s ease, border-color 0.2s ease;
+}
+
+.match-archive-item:hover {
+    transform: translateY(-2px);
+    border-color: rgba(96, 165, 250, 0.55);
+}
+
+.match-archive-top,
+.match-archive-meta {
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    gap: 8px;
+}
+
+.match-date {
+    color: #cbd5e1;
+    font-size: 0.85rem;
+}
+
+.match-competition {
+    font-size: 0.72rem;
+    color: #60a5fa;
+    letter-spacing: 0.08em;
+}
+
+.match-archive-main {
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    gap: 12px;
+}
+
+.match-archive-grid {
+    display: grid;
+    grid-template-columns: minmax(220px, 1.2fr) minmax(160px, 0.9fr) auto;
+    align-items: center;
+    gap: 16px;
+}
+
+.match-mid-meta {
+    display: flex;
+    flex-direction: column;
+    gap: 4px;
+    color: #94a3b8;
+    font-size: 0.78rem;
+    border-left: 1px solid rgba(148, 163, 184, 0.22);
+    border-right: 1px solid rgba(148, 163, 184, 0.22);
+    padding: 4px 12px;
+}
+
+.match-opponent {
+    font-size: 1.05rem;
+    font-weight: 700;
+    color: #f8fafc;
+}
+
+.match-context {
+    margin-top: 3px;
+    font-size: 0.75rem;
+    color: #94a3b8;
+    letter-spacing: 0.04em;
+}
+
+.match-score-wrap {
+    text-align: right;
+}
+
+.match-score {
+    font-size: 1.4rem;
+    font-weight: 800;
+    color: #f8fafc;
+}
+
+.match-meta-chip,
+.player-chip {
+    padding: 4px 8px;
+    border-radius: 999px;
+    font-size: 0.72rem;
+    color: #cbd5e1;
+    background: rgba(51, 65, 85, 0.65);
+    border: 1px solid rgba(148, 163, 184, 0.25);
+}
+
+.player-rank-item {
+    background: linear-gradient(145deg, rgba(15, 23, 42, 0.98), rgba(30, 41, 59, 0.86));
+    border: 1px solid rgba(71, 85, 105, 0.45);
+    border-radius: 14px;
+    padding: 12px 14px;
+    display: grid;
+    grid-template-columns: 42px minmax(180px, 1fr) minmax(140px, 0.9fr) auto;
+    align-items: center;
+    gap: 12px;
+    transition: border-color 0.2s ease, transform 0.2s ease;
+}
+
+.player-rank-item:hover {
+    border-color: rgba(37, 99, 235, 0.6);
+    transform: translateY(-1px);
+}
+
+.player-rank-order {
+    width: 36px;
+    height: 36px;
+    border-radius: 50%;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    background: linear-gradient(160deg, #1e40af, #2563eb);
+    color: #eff6ff;
+    font-weight: 700;
+    font-size: 0.9rem;
+}
+
+.player-name {
+    font-size: 1rem;
+    font-weight: 700;
+    color: #f8fafc;
+    margin-bottom: 6px;
+}
+
+.player-support {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 6px;
+}
+
+.player-rank-stats {
+    display: flex;
+    flex-direction: column;
+    align-items: flex-end;
+    gap: 6px;
+}
+
+.player-rank-meta {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 6px;
+    justify-content: flex-start;
 }
 
 .players-table, .matches-table, .regional-table {
@@ -337,13 +532,13 @@ body::before {
 .regional-table th, .regional-table td {
     padding: 10px;
     text-align: left;
-    border-bottom: 1px solid #ddd;
+    border-bottom: 1px solid rgba(148, 163, 184, 0.2);
     font-size: 0.9em;
 }
 
 .players-table th, .matches-table th, .regional-table th {
-    background: #1e40af;
-    color: white;
+    background: #1e293b;
+    color: #f8fafc;
     font-weight: bold;
     position: sticky;
     top: 0;
@@ -352,11 +547,11 @@ body::before {
 }
 
 .players-table th:hover, .matches-table th:hover, .regional-table th:hover {
-    background: #1d4ed8;
+    background: #334155;
 }
 
 .players-table tr:hover, .matches-table tr:hover, .regional-table tr:hover {
-    background: #f5f5f5;
+    background: rgba(30, 41, 59, 0.75);
 }
 
 .attendance-rate {
@@ -418,8 +613,8 @@ body::before {
 }
 
 .result-draw {
-    background: #fbbf24;
-    color: #333;
+    background: #f59e0b;
+    color: #fff;
 }
 
 .result-loss {
@@ -431,8 +626,8 @@ body::before {
     min-height: 0;
     overflow-y: auto;
     border-radius: 8px;
-    border: 1px solid #ddd;
-    max-height: 300px;
+    border: 1px solid rgba(148, 163, 184, 0.3);
+    max-height: 360px;
 }
 
 .team-record-card {
@@ -498,23 +693,24 @@ body::before {
 }
 
 .regional-records-section {
-    background: #f8f9fa;
+    background: rgba(15, 23, 42, 0.72);
+    border: 1px solid rgba(148, 163, 184, 0.22);
     padding: 25px;
     border-radius: 15px;
     margin-top: 30px;
     grid-column: 1 / -1;
-    height: 620px;
+    min-height: 560px;
     display: flex;
     flex-direction: column;
     gap: 14px;
 }
 
 .regional-records-section .table-container {
-    max-height: 380px;
+    max-height: 340px;
 }
 
 .all-time-view .regional-records-section {
-    height: 620px;
+    min-height: 560px;
 }
 
 .winrate-cell {
@@ -544,11 +740,12 @@ body::before {
 }
 
 .next-matches-section {
-    background: #f8f9fa;
+    background: rgba(15, 23, 42, 0.72);
+    border: 1px solid rgba(148, 163, 184, 0.22);
     padding: 25px;
     border-radius: 15px;
     margin-top: 60px;
-    border-top: 2px solid #e9ecef;
+    border-top: 1px solid rgba(148, 163, 184, 0.22);
 }
 
 .all-time-view .next-matches-section {
@@ -563,15 +760,16 @@ body::before {
 }
 
 .schedule-container {
-    background: white;
+    background: rgba(15, 23, 42, 0.78);
+    border: 1px solid rgba(148, 163, 184, 0.22);
     padding: 20px;
     border-radius: 10px;
     box-shadow: 0 2px 8px rgba(0,0,0,0.1);
 }
 
 .schedule-item {
-    background: linear-gradient(135deg, #1e40af, #60a5fa);
-    color: white;
+    background: linear-gradient(135deg, #0f172a, #1e3a8a);
+    color: #f8fafc;
     border-radius: 12px;
     padding: 20px;
     margin: 10px 0;
@@ -597,7 +795,8 @@ body::before {
 }
 
 .map-container {
-    background: white;
+    background: rgba(15, 23, 42, 0.78);
+    border: 1px solid rgba(148, 163, 184, 0.22);
     padding: 20px;
     border-radius: 10px;
     box-shadow: 0 2px 8px rgba(0,0,0,0.1);
@@ -632,19 +831,19 @@ body::before {
 
 .venue-name {
     font-weight: bold;
-    color: #1e40af;
+    color: #60a5fa;
     font-size: 1.2em;
     margin-bottom: 5px;
 }
 
 .venue-address {
-    color: #666;
+    color: #cbd5e1;
     font-size: 0.9em;
     margin-bottom: 5px;
 }
 
 .venue-phone {
-    color: #666;
+    color: #cbd5e1;
     font-size: 0.9em;
 }
 
@@ -795,18 +994,18 @@ body::before {
 }
 
 .schedule-list li {
-    background: white;
+    background: rgba(15, 23, 42, 0.85);
     border-radius: 10px;
     padding: 10px 12px;
-    border: 1px solid #e2e8f0;
-    box-shadow: 0 1px 4px rgba(0, 0, 0, 0.05);
+    border: 1px solid rgba(148, 163, 184, 0.2);
+    box-shadow: 0 1px 4px rgba(0, 0, 0, 0.15);
 }
 
 .filter-btn {
     padding: 8px 15px;
-    border: 2px solid #1e40af;
-    background: white;
-    color: #1e40af;
+    border: 1px solid #334155;
+    background: #0f172a;
+    color: #cbd5e1;
     border-radius: 20px;
     cursor: pointer;
     font-size: 0.9em;
@@ -814,13 +1013,14 @@ body::before {
 }
 
 .filter-btn.active {
-    background: #1e40af;
-    color: white;
+    background: #2563eb;
+    color: #eff6ff;
+    border-color: #2563eb;
 }
 
 .no-data {
     text-align: center;
-    color: #666;
+    color: #94a3b8;
     font-style: italic;
     padding: 20px;
 }
@@ -857,6 +1057,100 @@ body::before {
     margin-top: 5px;
 }
 
+.top-tabbar {
+    position: sticky;
+    top: 8px;
+    z-index: 40;
+    margin-top: 8px;
+    background: rgba(15, 23, 42, 0.96);
+    border: 1px solid rgba(148, 163, 184, 0.25);
+    border-radius: 16px;
+    padding: 8px;
+    display: grid;
+    grid-template-columns: repeat(5, 1fr);
+    gap: 8px;
+}
+
+.top-tab {
+    border: 1px solid transparent;
+    border-radius: 12px;
+    background: transparent;
+    color: #94a3b8;
+    padding: 10px 8px;
+    font-size: 0.82rem;
+    font-weight: 600;
+    cursor: pointer;
+}
+
+.top-tab.active {
+    background: #2563eb;
+    color: #eff6ff;
+    border-color: #3b82f6;
+}
+
+body.page-mode-home #mainContent,
+body.page-mode-home #allTimeContent {
+    display: none !important;
+}
+
+body:not(.page-mode-home) .hero-panel {
+    display: none;
+}
+
+body.page-mode-seasons #mainContent {
+    display: grid !important;
+}
+
+body.page-mode-seasons #allTimeContent {
+    display: none !important;
+}
+
+body.page-mode-matches #statsOverview,
+body.page-mode-matches #scheduleSection {
+    display: none !important;
+}
+
+body.page-mode-matches #mainContent {
+    display: grid !important;
+    grid-template-columns: 1fr !important;
+}
+
+body.page-mode-matches #mainContent .section:not(#matchesSection) {
+    display: none !important;
+}
+
+body.page-mode-matches #allTimeContent {
+    display: none !important;
+}
+
+body.page-mode-players #statsOverview,
+body.page-mode-players #scheduleSection {
+    display: none !important;
+}
+
+body.page-mode-players #mainContent {
+    display: grid !important;
+    grid-template-columns: 1fr !important;
+}
+
+body.page-mode-players #matchesSection {
+    display: none !important;
+}
+
+body.page-mode-players #allTimeContent {
+    display: none !important;
+}
+
+body.page-mode-records #statsOverview,
+body.page-mode-records #scheduleSection,
+body.page-mode-records #mainContent {
+    display: none !important;
+}
+
+body.page-mode-records #allTimeContent {
+    display: grid !important;
+}
+
 .sort-indicator {
     display: inline-block;
     margin-left: 5px;
@@ -869,14 +1163,22 @@ body::before {
     }
 
     .season-selector {
-        flex-direction: column;
-        gap: 10px;
+        flex-direction: row;
+        gap: 8px;
+    }
+
+    .hero-panel {
+        padding: 16px;
+    }
+
+    .hero-title {
+        font-size: 1.2rem;
     }
 
     .season-selector select, .all-time-button {
-        min-width: 140px;
-        font-size: 1em;
-        padding: 10px 15px;
+        min-width: 132px;
+        font-size: 0.92em;
+        padding: 8px 12px;
     }
 
     .main-content, .all-time-content {
@@ -891,6 +1193,61 @@ body::before {
         grid-template-columns: repeat(2, 1fr);
     }
 
+    .stat-card {
+        padding: 14px;
+        min-height: 148px;
+    }
+
+    .stat-value {
+        font-size: 2rem;
+    }
+
+    body.page-mode-home .hero-panel {
+        display: none;
+    }
+
+    body.page-mode-home .container {
+        display: flex;
+        flex-direction: column;
+    }
+
+    body.page-mode-home #scheduleSection {
+        order: 2;
+        margin-top: 14px;
+        margin-bottom: 12px;
+        border-bottom: 1px solid rgba(148, 163, 184, 0.25);
+        padding-bottom: 16px;
+    }
+
+    body.page-mode-home #statsOverview {
+        order: 3;
+        margin-bottom: 20px;
+    }
+
+    body.page-mode-home #mainContent {
+        display: grid !important;
+        grid-template-columns: 1fr !important;
+        order: 4;
+    }
+
+    body.page-mode-home #mainContent .section {
+        min-height: 0;
+        height: auto !important;
+        margin-bottom: 12px;
+    }
+
+    .top-tabbar {
+        top: 4px;
+        margin-top: 4px;
+        gap: 4px;
+        padding: 6px;
+    }
+
+    .top-tab {
+        font-size: 0.73rem;
+        padding: 8px 4px;
+    }
+
     .team-name {
         font-size: 2em;
     }
@@ -901,6 +1258,47 @@ body::before {
         padding: 3px 5px !important;
         font-size: 0.8em !important;
         line-height: 1.3 !important;
+    }
+
+    .match-archive-item {
+        padding: 12px;
+        border-radius: 12px;
+    }
+
+    .match-archive-main {
+        align-items: flex-start;
+    }
+
+    .match-archive-grid {
+        grid-template-columns: 1fr;
+        gap: 10px;
+    }
+
+    .match-mid-meta {
+        border-left: none;
+        border-right: none;
+        border-top: 1px solid rgba(148, 163, 184, 0.2);
+        border-bottom: 1px solid rgba(148, 163, 184, 0.2);
+        padding: 8px 0;
+    }
+
+    .match-score {
+        font-size: 1.2rem;
+    }
+
+    .player-rank-item {
+        grid-template-columns: 34px 1fr;
+        gap: 10px;
+    }
+
+    .player-rank-meta {
+        grid-column: 1 / -1;
+    }
+
+    .player-rank-stats {
+        grid-column: 1 / -1;
+        flex-direction: row;
+        justify-content: flex-end;
     }
 
     .table-container {
@@ -960,6 +1358,41 @@ body::before {
 
     .matches-table th:nth-child(5), .matches-table td:nth-child(5) {
         width: 30%;
+    }
+
+    .matches-table thead {
+        display: none;
+    }
+
+    .matches-table tbody tr {
+        display: block;
+        border: 1px solid #dbeafe;
+        border-radius: 10px;
+        padding: 8px 10px;
+        margin-bottom: 10px;
+        background: #ffffff;
+    }
+
+    .matches-table tbody td {
+        display: flex;
+        justify-content: space-between;
+        align-items: center;
+        width: 100% !important;
+        border-bottom: 1px dashed #e5e7eb;
+        padding: 6px 4px !important;
+        font-size: 0.85em !important;
+    }
+
+    .matches-table tbody td::before {
+        content: attr(data-label);
+        color: #475569;
+        font-weight: 700;
+        margin-right: 10px;
+        min-width: 48px;
+    }
+
+    .matches-table tbody td:last-child {
+        border-bottom: none;
     }
 
     .regional-table th:nth-child(1), .regional-table td:nth-child(1) {
@@ -1027,16 +1460,27 @@ body::before {
     #map, .map-placeholder {
         height: 250px;
     }
+
+    .top-tabbar {
+        gap: 4px;
+        padding: 6px;
+    }
+
+    .top-tab {
+        font-size: 0.72rem;
+        padding: 8px 4px;
+    }
 }
 
 @media (max-width: 480px) {
     .stats-overview {
-        grid-template-columns: 1fr;
-        gap: 15px;
+        grid-template-columns: repeat(2, minmax(0, 1fr));
+        gap: 10px;
     }
 
     .stat-card {
-        padding: 20px;
+        padding: 12px;
+        min-height: 132px;
     }
 
     .schedule-item {


### PR DESCRIPTION
### Motivation
- Modernize the dashboard UI with a dark-themed, card-first layout and improved mobile responsiveness to make season, match, player and all-time views clearer. 
- Replace dense tables with readable archive and ranking lists for better scanning on small screens and add simple top-level navigation for focused views. 
- Add client-side sort/filter controls for matches and players to improve exploration without reloading data. 
- Centralize view state so the app can switch between season and all-time modes and remember the active tab and sort order.

### Description
- Updated `index.html` to add a `top-tabbar`, a `hero-panel`, replace the matches table with a `match-archive-list` (`#matchesList`) and replace the players table with a `player-ranking-list` (`#playersRankList`), and adjusted all-time section structure. 
- Reworked `script.js` state and UI logic: added `AppState.ui.currentMainTab` and `currentMatchSort`, implemented `setMatchSort` and `switchMainTab`, refactored `updateMatchesTable` and `updatePlayersTable` to render card/list DOM instead of table rows, and updated `updateViewVisibility` to toggle `body` page-mode classes and top-tab active state. 
- Adjusted data flow in `loadData` and error handling to write into new list containers (`playersRankList`, `matchesList`) and updated `updateTable` call sites to use the new IDs. 
- Overhauled `styles.css` to a dark theme and responsive card layout, added styles for `.match-archive-item`, `.player-rank-item`, `.top-tabbar`, hero panel, new responsive rules and page-mode visibility controls, and hid the legacy `.all-time-button` by default. 
- Exposed new globals for HTML bindings: `switchMainTab` and `setMatchSort` in addition to existing window functions.

### Testing
- No automated tests were added or executed for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69ba5fb94de08333ace4c6e5f8c7e637)