### PR TITLE
Auto-fill region/venue, Kakao lookup, and regional stats support

### DIFF
--- a/admin.html
+++ b/admin.html
@@ -180,7 +180,8 @@
           <div class="form-group"><label>상대 득점</label><input type="number" id="m-opp" min="0" value="0"/></div>
           <div class="form-group"><label>용병 수</label><input type="number" id="m-merc" min="0" value="0"/></div>
         </div>
-        <div class="form-row">
+        <div class="form-row col2">
+          <div class="form-group"><label>지역</label><input type="text" id="m-region" list="regionOptions" placeholder="예: 노원구"/></div>
           <div class="form-group"><label>장소</label><input type="text" id="m-venue" placeholder="예: 은로초등학교"/></div>
         </div>
       </div>
@@ -228,7 +229,8 @@
           <div class="form-group"><label>상대 득점</label><input type="number" id="e-opp" min="0" value="0"/></div>
           <div class="form-group"><label>용병 수</label><input type="number" id="e-merc" min="0" value="0"/></div>
         </div>
-        <div class="form-row">
+        <div class="form-row col2">
+          <div class="form-group"><label>지역</label><input type="text" id="e-region" list="regionOptions" placeholder="예: 노원구"/></div>
           <div class="form-group"><label>장소</label><input type="text" id="e-venue"/></div>
         </div>
       </div>
@@ -308,6 +310,8 @@
 
 <div class="toast" id="toast"></div>
 
+<datalist id="regionOptions"></datalist>
+
 <script>
 // ── 보안/통신 설정 ──
 const SUPABASE_URL = "https://sgzanwxgdcyojcoskseo.supabase.co";
@@ -385,9 +389,209 @@ function switchTab(tab) {
 let allPlayers = [];
 let editingMatchId = null;
 let editingScheduleId = null;
-let scheduleMap = null; let scheduleMarker = null; let geocoder = null;
+let scheduleMap = null; let scheduleMarker = null; let geocoder = null; let placeSearchService = null;
+
+const REGION_OPTIONS = [
+    '강남구','강동구','강북구','강서구','관악구','광진구','구로구','금천구','노원구','도봉구','동대문구','동작구','마포구','서대문구','서초구','성동구','성북구','송파구','양천구','영등포구','용산구','은평구','종로구','중구','중랑구',
+    '고양시','광명시','구리시','군포시','김포시','남양주시','부천시','성남시','수원시','시흥시','안양시','양주시','양평군','용인시','의왕시','의정부시','파주시','평택시','하남시'
+];
+const REGION_VENUE_SEPARATOR = ' | ';
+const KAKAO_REGION_SEARCH_DELAY = 600;
+const KAKAO_REGION_LOOKUP_TIMEOUT = 2200;
+const venueRegionSearchTimers = {};
+const VENUE_REGION_MAP = [
+    ['은로초등학교', '노원구'],
+    ['은로초', '노원구'],
+    ['은호초등학교', '노원구'],
+    ['은호초', '노원구'],
+    ['망우중학교', '중랑구'],
+    ['망우중', '중랑구'],
+    ['성불빌라', '노원구']
+];
+
+function renderRegionOptions() {
+    const datalist = document.getElementById('regionOptions');
+    if (!datalist) return;
+    datalist.innerHTML = REGION_OPTIONS.map(region => `<option value="${region}"></option>`).join('');
+}
+
+function normalizeRegion(region) {
+    const value = (region || '').trim();
+    if (!value) return '';
+    const exact = REGION_OPTIONS.find(option => option === value);
+    if (exact) return exact;
+    return REGION_OPTIONS.find(option => value.includes(option) || option.includes(value)) || value;
+}
+
+function normalizeVenueKeyword(value) {
+    return (value || '').replace(/\s/g, '').toLowerCase();
+}
+
+function inferRegionFromVenue(venue) {
+    const value = (venue || '').trim();
+    if (!value) return '';
+
+    const explicitRegion = extractRegionFromText(value);
+    if (explicitRegion) return explicitRegion;
+
+    const normalizedVenue = normalizeVenueKeyword(value);
+    if (normalizedVenue.length < 2) return '';
+
+    const match = VENUE_REGION_MAP.find(([venueName]) => {
+        const normalizedName = normalizeVenueKeyword(venueName);
+        return normalizedVenue.includes(normalizedName) || normalizedName.includes(normalizedVenue);
+    });
+    return match ? match[1] : '';
+}
+
+function ensureKakaoServices() {
+    if (typeof kakao === 'undefined' || !kakao.maps || !kakao.maps.services) return false;
+    if (!geocoder) geocoder = new kakao.maps.services.Geocoder();
+    if (!placeSearchService) placeSearchService = new kakao.maps.services.Places();
+    return true;
+}
+
+function extractRegionFromKakaoResult(result) {
+    if (!result) return '';
+    return extractRegionFromText([
+        result.road_address_name,
+        result.address_name,
+        result.place_name
+    ].filter(Boolean).join(' '));
+}
+
+function findRegionInKakaoResults(results = []) {
+    const match = (results || [])
+        .map(extractRegionFromKakaoResult)
+        .find(Boolean);
+    return match || '';
+}
+
+function lookupRegionWithKakao(venue, timeoutMs = KAKAO_REGION_LOOKUP_TIMEOUT) {
+    const query = (venue || '').trim();
+    if (query.length < 2 || !ensureKakaoServices()) return Promise.resolve('');
+
+    return new Promise(resolve => {
+        let settled = false;
+        const finish = (region = '') => {
+            if (settled) return;
+            settled = true;
+            resolve(normalizeRegion(region));
+        };
+
+        const searchByKeyword = () => {
+            placeSearchService.keywordSearch(query, (places, status) => {
+                if (status === kakao.maps.services.Status.OK) {
+                    finish(findRegionInKakaoResults(places));
+                } else {
+                    finish('');
+                }
+            }, { size: 5 });
+        };
+
+        geocoder.addressSearch(query, (results, status) => {
+            if (status === kakao.maps.services.Status.OK) {
+                const region = findRegionInKakaoResults(results);
+                if (region) {
+                    finish(region);
+                    return;
+                }
+            }
+            searchByKeyword();
+        });
+
+        setTimeout(() => finish(''), timeoutMs);
+    });
+}
+
+function extractRegionFromText(text) {
+    const value = (text || '').trim();
+    if (!value) return '';
+    if (value.includes(REGION_VENUE_SEPARATOR)) {
+        const separatedRegion = value.split(REGION_VENUE_SEPARATOR)[0]?.trim();
+        return normalizeRegion(separatedRegion);
+    }
+    return REGION_OPTIONS.find(option => value.includes(option)) || '';
+}
+
+function splitVenueRegion(value = '') {
+    const venue = (value || '').trim();
+    if (!venue) return { region: '', venue: '' };
+    if (venue.includes(REGION_VENUE_SEPARATOR)) {
+        const [regionPart, ...venueParts] = venue.split(REGION_VENUE_SEPARATOR);
+        return { region: normalizeRegion(regionPart), venue: venueParts.join(REGION_VENUE_SEPARATOR).trim() };
+    }
+    return { region: inferRegionFromVenue(venue), venue };
+}
+
+function buildVenueValue(region, venue) {
+    const cleanVenue = (venue || '').trim();
+    const normalizedRegion = normalizeRegion(region || inferRegionFromVenue(cleanVenue));
+    if (normalizedRegion && cleanVenue) return `${normalizedRegion}${REGION_VENUE_SEPARATOR}${cleanVenue}`;
+    return cleanVenue || normalizedRegion;
+}
+
+function scheduleKakaoVenueRegionMapping(venueInputId, regionInputId, force = false) {
+    clearTimeout(venueRegionSearchTimers[venueInputId]);
+    venueRegionSearchTimers[venueInputId] = setTimeout(async () => {
+        const venueInput = document.getElementById(venueInputId);
+        const regionInput = document.getElementById(regionInputId);
+        if (!venueInput || !regionInput) return;
+        if (!force && regionInput.value.trim()) return;
+
+        const searchValue = venueInput.value.trim();
+        const region = await lookupRegionWithKakao(searchValue);
+        if (region && venueInput.value.trim() === searchValue && (force || !regionInput.value.trim())) {
+            regionInput.value = region;
+        }
+    }, KAKAO_REGION_SEARCH_DELAY);
+}
+
+function applyVenueRegionMapping(venueInputId, regionInputId, force = false) {
+    const venueInput = document.getElementById(venueInputId);
+    const regionInput = document.getElementById(regionInputId);
+    if (!venueInput || !regionInput) return;
+
+    const inferredRegion = inferRegionFromVenue(venueInput.value);
+    if (inferredRegion && (force || !regionInput.value.trim())) {
+        regionInput.value = inferredRegion;
+        return;
+    }
+
+    scheduleKakaoVenueRegionMapping(venueInputId, regionInputId, force);
+}
+
+async function buildVenueValueWithKakao(regionInputId, venueInputId) {
+    const regionInput = document.getElementById(regionInputId);
+    const venueInput = document.getElementById(venueInputId);
+    const cleanVenue = (venueInput?.value || '').trim();
+    let region = normalizeRegion(regionInput?.value || inferRegionFromVenue(cleanVenue));
+
+    if (!region) {
+        region = await lookupRegionWithKakao(cleanVenue);
+        if (region && regionInput) regionInput.value = region;
+    }
+
+    return buildVenueValue(region, cleanVenue);
+}
+
+function setupVenueRegionAutoFill() {
+    [
+        ['m-venue', 'm-region'],
+        ['e-venue', 'e-region']
+    ].forEach(([venueInputId, regionInputId]) => {
+        const venueInput = document.getElementById(venueInputId);
+        if (!venueInput || venueInput.dataset.regionAutoFillBound === 'true') return;
+        venueInput.dataset.regionAutoFillBound = 'true';
+        ['input', 'change', 'blur'].forEach(eventName => {
+            venueInput.addEventListener(eventName, () => applyVenueRegionMapping(venueInputId, regionInputId));
+        });
+    });
+}
 
 async function init() {
+    renderRegionOptions();
+    setupVenueRegionAutoFill();
     await loadPlayers();
     renderLineupGrid();
     renderPlayerTable();
@@ -499,7 +703,7 @@ async function saveMatch() {
         const opponent = document.getElementById("m-opponent").value.trim();
         const ourScore = parseInt(document.getElementById("m-our").value) || 0;
         const oppScore = parseInt(document.getElementById("m-opp").value) || 0;
-        const venue = document.getElementById("m-venue").value.trim();
+        const venue = await buildVenueValueWithKakao("m-region", "m-venue");
         const mercCount = parseInt(document.getElementById("m-merc").value) || 0;
         const mvpName = document.getElementById("m-mvp").value.trim();
 
@@ -539,7 +743,7 @@ async function saveMatch() {
 function resetMatchForm() {
     document.getElementById("m-date").value = ""; document.getElementById("m-opponent").value = "";
     document.getElementById("m-our").value = "0"; document.getElementById("m-opp").value = "0";
-    document.getElementById("m-merc").value = "0"; document.getElementById("m-venue").value = "";
+    document.getElementById("m-merc").value = "0"; document.getElementById("m-region").value = ""; document.getElementById("m-venue").value = "";
     document.getElementById("m-mvp").value = ""; document.getElementById("searchLineup").value = "";
     document.getElementById("goalList").innerHTML = "";
     document.querySelectorAll(".player-check").forEach(l => { l.style.display = "flex"; l.classList.remove("checked"); l.querySelector("input").checked = false; });
@@ -552,7 +756,7 @@ async function loadRecentMatches() {
     tbody.innerHTML = '<tr><td colspan="4">불러오는 중...</td></tr>';
 
     try {
-        const matches = await sbFetch("GET", "matches", null, "?season=eq.2026&order=date.desc,created_at.desc&limit=20");
+        const matches = await sbFetch("GET", "matches", null, "?order=date.desc,created_at.desc&limit=20");
         tbody.innerHTML = matches.map(match => `
             <tr>
                 <td>${match.date}</td>
@@ -589,7 +793,9 @@ async function loadMatchForEdit(matchId) {
         document.getElementById("e-opponent").value = match.opponent || "";
         document.getElementById("e-our").value = match.our_score ?? 0;
         document.getElementById("e-opp").value = match.opp_score ?? 0;
-        document.getElementById("e-venue").value = match.venue || "";
+        const venueRegion = splitVenueRegion(match.venue || "");
+        document.getElementById("e-region").value = venueRegion.region;
+        document.getElementById("e-venue").value = venueRegion.venue;
         document.getElementById("e-merc").value = lineups.filter(l => l.is_mercenary).length;
 
         const selectedRosterIds = lineups.filter(l => !l.is_mercenary).map(lineup => {
@@ -684,7 +890,7 @@ async function updateMatch() {
         const opponent = document.getElementById("e-opponent").value.trim();
         const ourScore = parseInt(document.getElementById("e-our").value) || 0;
         const oppScore = parseInt(document.getElementById("e-opp").value) || 0;
-        const venue = document.getElementById("e-venue").value.trim();
+        const venue = await buildVenueValueWithKakao("e-region", "e-venue");
         const mercCount = parseInt(document.getElementById("e-merc").value) || 0;
         const mvpName = document.getElementById("e-mvp").value.trim();
         const checked = getEditCheckedPlayers();
@@ -771,6 +977,7 @@ function initKakaoMap() {
     const options = { center: new kakao.maps.LatLng(37.5665, 126.9780), level: 3 };
     scheduleMap = new kakao.maps.Map(container, options);
     geocoder = new kakao.maps.services.Geocoder();
+    placeSearchService = new kakao.maps.services.Places();
 }
 
 let searchTimer;

--- a/script.js
+++ b/script.js
@@ -92,6 +92,97 @@ const CONFIG = {
     }
 };
 
+const REGION_OPTIONS = [
+    '강남구','강동구','강북구','강서구','관악구','광진구','구로구','금천구','노원구','도봉구','동대문구','동작구','마포구','서대문구','서초구','성동구','성북구','송파구','양천구','영등포구','용산구','은평구','종로구','중구','중랑구',
+    '고양시','광명시','구리시','군포시','김포시','남양주시','부천시','성남시','수원시','시흥시','안양시','양주시','양평군','용인시','의왕시','의정부시','파주시','평택시','하남시'
+];
+const REGION_VENUE_SEPARATOR = ' | ';
+const VENUE_REGION_MAP = [
+    ['은로초등학교', '노원구'],
+    ['은로초', '노원구'],
+    ['은호초등학교', '노원구'],
+    ['은호초', '노원구'],
+    ['망우중학교', '중랑구'],
+    ['망우중', '중랑구'],
+    ['성불빌라', '노원구']
+];
+
+function normalizeRegion(region) {
+    const value = sanitizeTableData(region || '').trim();
+    if (!value) return '';
+    const exact = REGION_OPTIONS.find(option => option === value);
+    if (exact) return exact;
+    return REGION_OPTIONS.find(option => value.includes(option) || option.includes(value)) || value;
+}
+
+function extractRegionFromText(text) {
+    const value = sanitizeTableData(text || '').trim();
+    if (!value) return '';
+    if (value.includes(REGION_VENUE_SEPARATOR)) {
+        const separatedRegion = value.split(REGION_VENUE_SEPARATOR)[0]?.trim();
+        return normalizeRegion(separatedRegion);
+    }
+    return REGION_OPTIONS.find(option => value.includes(option)) || '';
+}
+
+function normalizeVenueKeyword(value) {
+    return sanitizeTableData(value || '').replace(/\s/g, '').toLowerCase();
+}
+
+function inferRegionFromVenue(venue) {
+    const value = sanitizeTableData(venue || '').trim();
+    if (!value) return '';
+
+    const explicitRegion = extractRegionFromText(value);
+    if (explicitRegion) return explicitRegion;
+
+    const normalizedVenue = normalizeVenueKeyword(value);
+    if (normalizedVenue.length < 2) return '';
+
+    const match = VENUE_REGION_MAP.find(([venueName]) => {
+        const normalizedName = normalizeVenueKeyword(venueName);
+        return normalizedVenue.includes(normalizedName) || normalizedName.includes(normalizedVenue);
+    });
+    return match ? match[1] : '';
+}
+
+function stripRegionFromVenue(venue = '') {
+    const value = sanitizeTableData(venue || '').trim();
+    if (!value) return '';
+    if (!value.includes(REGION_VENUE_SEPARATOR)) return value;
+    return value.split(REGION_VENUE_SEPARATOR).slice(1).join(REGION_VENUE_SEPARATOR).trim();
+}
+
+function calculateRegionalStatsFromMatches(matches = []) {
+    const regionalMap = new Map();
+    const overall = { region: '전체', matches: 0, wins: 0, draws: 0, losses: 0 };
+
+    matches.forEach(match => {
+        const region = normalizeRegion(match.region || inferRegionFromVenue(match.venue));
+        if (!region) return;
+
+        const row = regionalMap.get(region) || { region, matches: 0, wins: 0, draws: 0, losses: 0 };
+        row.matches += 1;
+        overall.matches += 1;
+
+        if (match.result === 'win') {
+            row.wins += 1;
+            overall.wins += 1;
+        } else if (match.result === 'draw') {
+            row.draws += 1;
+            overall.draws += 1;
+        } else {
+            row.losses += 1;
+            overall.losses += 1;
+        }
+
+        regionalMap.set(region, row);
+    });
+
+    const rows = Array.from(regionalMap.values());
+    return rows.length > 0 ? [overall, ...rows] : [];
+}
+
 const MANUAL_ALLTIME_PLAYER_RECORDS = Object.fromEntries([
     ['강규주', { totalAppearances: 5, totalGoals: 0 }],
     ['강동규', { totalAppearances: 1, totalGoals: 1 }],
@@ -1264,14 +1355,15 @@ function initializeMap() {
 
 // --- [ 데이터 로드 함수 ] ---
 
-async function loadFromGoogleSheets(season) {
+async function loadFromSupabase(season) {
     const season2026plus = parseInt(season) >= 2026;
 
     // 1단계: 경기 ID 목록 먼저
     const matchIdList = await supabaseFetch(
-        `matches?season=eq.${season}&select=id`
+        `matches?season=eq.${season}&select=id,venue`
     );
     const matchIds = matchIdList.map(m => m.id).join(",") || "0";
+    const venueByMatchId = new Map(matchIdList.map(match => [match.id, match.venue || '']));
 
     // 💡 오늘 날짜 구하기 (지나간 일정은 안 보이게)
     const today = new Date().toISOString().split('T')[0];
@@ -1304,14 +1396,18 @@ async function loadFromGoogleSheets(season) {
         mvpMap[row.match_id].push(row.raw_name);
     });
 
-    const matches = matchesRaw.map(m => ({
-        date: m.date,
-        opponent: m.opponent,
-        result: m.result === "W" ? "win" : m.result === "D" ? "draw" : "loss",
-        score: `${m.our_score}:${m.opp_score}`,
-        venue: m.venue || "",
-        mvp: (mvpMap[m.id] || []).join(", ")
-    }));
+    const matches = matchesRaw.map(m => {
+        const storedVenue = m.venue || venueByMatchId.get(m.id) || '';
+        return {
+            date: m.date,
+            opponent: m.opponent,
+            result: m.result === "W" ? "win" : m.result === "D" ? "draw" : "loss",
+            score: `${m.our_score}:${m.opp_score}`,
+            venue: stripRegionFromVenue(storedVenue),
+            region: normalizeRegion(m.region || inferRegionFromVenue(storedVenue)),
+            mvp: (mvpMap[m.id] || []).join(", ")
+        };
+    });
 
     // players 매핑
     const players = {};
@@ -1340,7 +1436,7 @@ async function loadFromGoogleSheets(season) {
         matches: matches,
         players: players,
         schedules: schedules, // 💡 더 이상 빈 배열([])이 아닌 진짜 데이터 연결!
-        regional: []
+        regional: calculateRegionalStatsFromMatches(matches)
     };
 }
 // JSON 경로를 명확히 지정하여 로드
@@ -1364,7 +1460,7 @@ async function loadData() {
             data = seasonDataCache.get(currentSeasonKey);
             dataSource = '캐시';
         } else {
-            data = await loadFromGoogleSheets(currentSeasonKey);
+            data = await loadFromSupabase(currentSeasonKey);
             seasonDataCache.set(currentSeasonKey, data);
         }
 
@@ -1420,7 +1516,7 @@ async function loadSeasonDataWithRetry(season, retries = 2) {
                 return { success: true, season: seasonKey, data: seasonDataCache.get(seasonKey) };
             }
 
-            const data = await loadFromGoogleSheets(seasonKey);
+            const data = await loadFromSupabase(seasonKey);
             seasonDataCache.set(seasonKey, data);
             return { success: true, season: seasonKey, data };
         } catch (error) {
@@ -1440,10 +1536,13 @@ async function loadAllTimeSeasonsParallel() {
     showStatusMessage('역대 기록을 불러오는 중...', 'loading');
 
     try {
-        const [playerStats, allMatches] = await Promise.all([
+        const [playerStats, allMatches, rawMatches] = await Promise.all([
             supabaseFetch('alltime_player_stats?select=name,total_appearances,total_goals,total_mvp&order=total_goals.desc'),
-            supabaseFetchAll('matches_with_result?select=season,date,opponent,our_score,opp_score,result&order=date.asc')
+            supabaseFetchAll('matches_with_result?select=*&order=date.asc'),
+            supabaseFetchAll('matches?select=id,date,opponent,venue&order=date.asc')
         ]);
+        const rawVenueById = new Map(rawMatches.map(match => [match.id, match.venue || '']));
+        const rawVenueByFallbackKey = new Map(rawMatches.map(match => [`${match.date}|${match.opponent}`, match.venue || '']));
 
         const allTimeStats = {};
         playerStats.forEach(p => {
@@ -1455,15 +1554,21 @@ async function loadAllTimeSeasonsParallel() {
         });
 
         // 역대 선수 기록은 DB raw 집계 뷰를 단일 기준으로 사용한다.
-        const matchesFormatted = allMatches.map(m => ({
-            season: m.season,
-            date: m.date,
-            opponent: m.opponent,
-            score: `${m.our_score}:${m.opp_score}`,
-            result: m.result === 'W' ? 'win' : m.result === 'D' ? 'draw' : 'loss'
-        }));
+        const matchesFormatted = allMatches.map(m => {
+            const storedVenue = m.venue || rawVenueById.get(m.id) || rawVenueByFallbackKey.get(`${m.date}|${m.opponent}`) || '';
+            return {
+                season: m.season,
+                date: m.date,
+                opponent: m.opponent,
+                score: `${m.our_score}:${m.opp_score}`,
+                venue: stripRegionFromVenue(storedVenue),
+                region: normalizeRegion(m.region || inferRegionFromVenue(storedVenue)),
+                result: m.result === 'W' ? 'win' : m.result === 'D' ? 'draw' : 'loss'
+            };
+        });
 
         const teamRecords = calculateTeamRecords(matchesFormatted);
+        const calculatedRegionalRecords = calculateRegionalStatsFromMatches(matchesFormatted);
         let debutTimeline = [];
 
         try {
@@ -1483,7 +1588,7 @@ async function loadAllTimeSeasonsParallel() {
             stats: allTimeStats,
             matches: matchesFormatted,
             records: teamRecords,
-            regional: MANUAL_ALLTIME_REGIONAL_RECORDS,
+            regional: calculatedRegionalRecords.length > 0 ? calculatedRegionalRecords : MANUAL_ALLTIME_REGIONAL_RECORDS,
             debuts: debutTimeline
         };
 


### PR DESCRIPTION
### Motivation
- Improve match and schedule data quality by separating and auto-detecting `region` and `venue`, and deriving region information when missing. 
- Use Kakao Maps/Places for fallback region lookup and provide a better UX in the admin UI when entering venues. 
- Calculate and expose regional statistics from match data so regional summaries can be shown in the UI.

### Description
- Admin UI: added `m-region` and `e-region` inputs and a `<datalist id="regionOptions">` to `admin.html`, and updated layout to show region + venue separately. 
- Auto-fill & Kakao integration: implemented region normalization/inference utilities (`normalizeRegion`, `inferRegionFromVenue`, `extractRegionFromText`, `splitVenueRegion`, `buildVenueValue`, `buildVenueValueWithKakao`, etc.), scheduled debounce search, and wired Kakao `Places`/`Geocoder` usage for venue->region lookup and mapping; added `placeSearchService` initialization. 
- Save/update flow: when saving or updating matches, call `buildVenueValueWithKakao` to persist a composed `region | venue` or cleaned venue and populate `m-region`/`e-region` on edit via `splitVenueRegion`. 
- Data loading and analytics: replaced legacy `loadFromGoogleSheets` with `loadFromSupabase`, included `schedules` load, preserved and normalized `venue`/`region` values when formatting matches, and added `calculateRegionalStatsFromMatches` to produce regional stats for both current-season and all-time views; updated all-time loader to prefer calculated regional data. 
- Misc: rendered `regionOptions` in the admin datalist, set up event handlers to auto-fill region on `input/change/blur`, added a small `VENUE_REGION_MAP` for quick heuristics, and removed a hard-coded season filter when loading recent matches.

### Testing
- Ran the project's JavaScript lint and test commands (`npm run lint` and `npm test`) against the modified files and they completed successfully. 
- Exercised the admin match save/update flows locally to verify `region` inference, Kakao lookup fallback, and that `region | venue` is persisted and loaded correctly into edit form.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a20dfb04f7c8333abf62eef3958e4a2)